### PR TITLE
Add mapping for headless Chrome

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,13 @@ function resolveUserAgent(uaString) {
     }
   }
 
+  if (parsedUA.family.indexOf('HeadlessChrome') > -1) {
+    return {
+      family: 'Chrome',
+      version: [parsedUA.major, parsedUA.minor, parsedUA.patch].join('.'),
+    }
+  }
+
   if (parsedUA.family === 'Firefox Mobile') {
     return {
       family: 'Firefox',

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -106,6 +106,14 @@ it('resolves chrome/android properly', () => {
     })
 })
 
+it('resolves headless chrome properly', () => {
+  expect(resolveUserAgent(ua.chrome('41.0.228.90').replace('Chrome', 'HeadlessChrome')))
+    .toEqual({
+      family: 'Chrome',
+      version: '41.0.228',
+    })
+})
+
 it('resolves firefox properly', () => {
   expect(resolveUserAgent(ua.firefox('41.0.0')))
     .toEqual({


### PR DESCRIPTION
When running with the `--headless` flag, Chrome advertises itself as 'HeadlessChrome'. This adds the appropriate mapping.