### PR TITLE
Resolve "Samsung Internet" as "Samsung" browser to match browserslist naming

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,13 @@ function resolveUserAgent(uaString) {
     }
   }
 
+  if (parsedUA.family === 'Samsung Internet') {
+    return {
+      family: 'Samsung',
+      version: [parsedUA.major, parsedUA.minor, parsedUA.patch].join('.'),
+    }
+  }
+
   return {
     family: parsedUA.family,
     version: [parsedUA.major, parsedUA.minor, parsedUA.patch].join('.'),

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -274,12 +274,12 @@ it('_allowHigherVersions and allowHigherVersions work correctly', () => {
     .toBeTruthy()
 
   // latest version of samsung browser reported by browserslist is 7.2.0
-  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_6_2, {browsers: ['samsung <= 7'], allowHigherVersions: false}))
+  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_6_2, {browsers: ['samsung >= 3'], allowHigherVersions: false}))
     .toBeTruthy()
 
-  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_7_4, {browsers: ['samsung <= 7'], allowHigherVersions: false}))
+  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_7_4, {browsers: ['samsung >= 3'], allowHigherVersions: false}))
     .toBeFalsy()
 
-  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_8_2, {browsers: ['samsung <= 7'], allowHigherVersions: false}))
+  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_8_2, {browsers: ['samsung >= 3'], allowHigherVersions: false}))
     .toBeFalsy()
 })

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -6,6 +6,7 @@ const CustomUserAgentString = {
   YANDEX: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 YaBrowser/18.1.1.839 Yowser/2.5 Safari/537.36",
   SAMSUNG_BROWSER_6_2: "Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-N920C Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36",
   SAMSUNG_BROWSER_8_2: "Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-N930F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36",
+  SAMSUNG_BROWSER_7_2: "Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G920P Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.2 Chrome/59.0.3071.125 Mobile Safari/537.36	",
   SAMSUNG_BROWSER_7_4: "Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-N930F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36"
 }
 
@@ -174,6 +175,12 @@ it('detects if browserslist matches UA', () => {
     .toBeTruthy()
 
   expect(matchesUA(ua.safari.iOS('11.0.0'), {browsers: ['iOS >= 10.3.0']}))
+    .toBeTruthy()
+
+  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_6_2, {browsers: ['Samsung >= 7']}))
+    .toBeFalsy()
+
+  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_7_2, {browsers: ['Samsung >= 7']}))
     .toBeTruthy()
 
   const modernList = [

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -4,6 +4,9 @@ const {resolveUserAgent, matchesUA, normalizeQuery} = require('../index')
 
 const CustomUserAgentString = {
   YANDEX: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 YaBrowser/18.1.1.839 Yowser/2.5 Safari/537.36",
+  SAMSUNG_BROWSER_6_2: "Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-N920C Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36",
+  SAMSUNG_BROWSER_8_2: "Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-N930F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36",
+  SAMSUNG_BROWSER_7_4: "Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-N930F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36"
 }
 
 it('normalizes queries properly', () => {
@@ -140,6 +143,26 @@ it('resolves firefox properly', () => {
     })
 })
 
+it('resolves samsung browser properly', () => {
+  expect(resolveUserAgent(CustomUserAgentString.SAMSUNG_BROWSER_6_2))
+    .toEqual({
+      family: 'Samsung',
+      version: '6.2.0'
+    })
+
+  expect(resolveUserAgent(CustomUserAgentString.SAMSUNG_BROWSER_7_4))
+    .toEqual({
+      family: 'Samsung',
+      version: '7.4.0'
+    })
+
+  expect(resolveUserAgent(CustomUserAgentString.SAMSUNG_BROWSER_8_2))
+    .toEqual({
+      family: 'Samsung',
+      version: '8.2.0'
+    })
+})
+
 it('detects if browserslist matches UA', () => {
   expect(matchesUA(ua.firefox.androidPhone('40.0.1'), {browsers: ['Firefox >= 40']}))
     .toBeTruthy()
@@ -240,4 +263,23 @@ it('_allowHigherVersions and allowHigherVersions work correctly', () => {
 
   expect(matchesUA(ua.chrome('66'), {browsers: ['chrome >= 60'], allowHigherVersions: true}))
     .toBeTruthy()
+
+  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_6_2, {browsers: ['samsung >= 3'], allowHigherVersions: true}))
+    .toBeTruthy()
+
+  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_7_4, {browsers: ['samsung >= 3'], allowHigherVersions: true}))
+    .toBeTruthy()
+
+  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_8_2, {browsers: ['samsung >= 3'], allowHigherVersions: true}))
+    .toBeTruthy()
+
+  // latest version of samsung browser reported by browserslist is 7.2.0
+  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_6_2, {browsers: ['samsung <= 7'], allowHigherVersions: false}))
+    .toBeTruthy()
+
+  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_7_4, {browsers: ['samsung <= 7'], allowHigherVersions: false}))
+    .toBeFalsy()
+
+  expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_8_2, {browsers: ['samsung <= 7'], allowHigherVersions: false}))
+    .toBeFalsy()
 })


### PR DESCRIPTION
`useragent` lib resolves "Samsung Internet" as `Samsung Internet` and this is correct. However, `browserslist` resolves it as `Samsung` what causes issues in UA matching