### PR TITLE
Add createUAMatcher to reuse configured browserslist

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,7 +176,7 @@ const compareBrowserSemvers = (versionA, versionB, options) => {
   }
 }
 
-const matchesUA = (uaString, opts) => {
+const createUAMatcher = (opts) => {
   let normalizedQuery
   if (opts && opts.browsers) {
     normalizedQuery = opts.browsers.map(normalizeQuery)
@@ -186,7 +186,6 @@ const matchesUA = (uaString, opts) => {
     path: process.cwd()
   })
   const parsedBrowsers = parseBrowsersList(browsers)
-  const resolvedUserAgent = resolveUserAgent(uaString)
 
   if(opts._allowHigherVersions) {
     console.warn('browserslist-useragent: The `_allowHigherVersions` option has been deprecated. Please use `allowHigherVersions` instead.')
@@ -199,15 +198,24 @@ const matchesUA = (uaString, opts) => {
     allowHigherVersions: opts._allowHigherVersions || opts.allowHigherVersions
   }
 
-  return parsedBrowsers.some(browser => {
-    return (
-      browser.family.toLowerCase() === resolvedUserAgent.family.toLocaleLowerCase() &&
-      compareBrowserSemvers(resolvedUserAgent.version, browser.version, options)
-    )
-  })
+  return (uaString) => {
+    const resolvedUserAgent = resolveUserAgent(uaString)
+
+    return parsedBrowsers.some(browser => {
+      return (
+        browser.family.toLowerCase() === resolvedUserAgent.family.toLocaleLowerCase() &&
+        compareBrowserSemvers(resolvedUserAgent.version, browser.version, options)
+      )
+    })
+  }
+}
+
+const matchesUA = (uaString, opts) => {
+  return createUAMatcher(opts)(uaString);
 }
 
 module.exports = {
+  createUAMatcher,
   matchesUA,
   resolveUserAgent,
   normalizeQuery,

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,6 +1,6 @@
 const ua = require('useragent-generator')
 
-const {resolveUserAgent, matchesUA, normalizeQuery} = require('../index')
+const {resolveUserAgent, createUAMatcher, matchesUA, normalizeQuery} = require('../index')
 
 const CustomUserAgentString = {
   YANDEX: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 YaBrowser/18.1.1.839 Yowser/2.5 Safari/537.36",
@@ -240,4 +240,11 @@ it('_allowHigherVersions and allowHigherVersions work correctly', () => {
 
   expect(matchesUA(ua.chrome('66'), {browsers: ['chrome >= 60'], allowHigherVersions: true}))
     .toBeTruthy()
+})
+
+it('createUAMatcher returns configured matchesUA function', () => {
+  const matches = createUAMatcher({browsers: ['Firefox >= 40']});
+
+  expect(matches(ua.firefox('39'))).toBeFalsy();
+  expect(matches(ua.firefox('40'))).toBeTruthy();
 })


### PR DESCRIPTION
We were using `matchUA` inside an express.js middleware and found that
it was quite expensive to create the browserslist for every request.

This changes introduces a new export `createUAMatcher` that can be used
to return an already configured `matchUA` function for a given
browserslist.

This improves performance when checking multiple user-agent strings
against the same browserslist.

Co-authored-by: Robin Drexler <drexler.robin@gmail.com>