### PR TITLE
 New matchesUA return signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,27 @@ const { matchesUA } = require('browserslist-useragent')
 
 matchesUA(userAgentString, options)
 
-// with browserslist config inferred
-matchesUA('Mozilla/5.0 (Windows NT 10.0; rv:54.0) Gecko/20100101 Firefox/54.0')
-//returns boolean
-
-// with explicit browserslist
+// With explicit browserslist config:
 matchesUA('Mozilla/5.0 (Windows NT 10.0; rv:54.0) Gecko/20100101 Firefox/54.0', { browsers: ['Firefox > 53']})
-// returns true
+// Returns:
+// {
+//   matches: true,
+//   userAgent: {
+//     family: 'Firefox',
+//     version: '54.0.0'
+//   }
+// }
+
+// With inferred browserslist config:
+matchesUA('Mozilla/5.0 (Windows NT 10.0; rv:54.0) Gecko/20100101 Firefox/54.0')
+
+// With an unrecognizable user agent:
+matchesUA('unrecognizable')
+// Returns:
+// {
+//   matches: false,
+//   userAgent: null
+// }
 ```
 
 | Option | Default Value | Description |

--- a/index.js
+++ b/index.js
@@ -209,12 +209,13 @@ const matchesUA = (uaString, opts) => {
     allowHigherVersions: opts._allowHigherVersions || opts.allowHigherVersions
   }
 
-  return parsedBrowsers.some(browser => {
-    return (
+  return {
+    matches: parsedBrowsers.some(browser => (
       browser.family.toLowerCase() === resolvedUserAgent.family.toLocaleLowerCase() &&
       compareBrowserSemvers(resolvedUserAgent.version, browser.version, options)
-    )
-  })
+    )),
+    userAgent: resolvedUserAgent.family === 'Other' ? null : resolvedUserAgent
+  }
 }
 
 module.exports = {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -127,7 +127,7 @@ it('resolves chrome/android properly', () => {
     })
 
   expect(matchesUA(CustomUserAgentString.YANDEX, { browsers: ['Chrome >= 63']}))
-    .toBe(true)
+    .toMatchObject({ matches: true })
 })
 
 it('resolves firefox properly', () => {
@@ -166,22 +166,58 @@ it('resolves samsung browser properly', () => {
 
 it('detects if browserslist matches UA', () => {
   expect(matchesUA(ua.firefox.androidPhone('40.0.1'), {browsers: ['Firefox >= 40']}))
-    .toBe(true)
+    .toEqual({
+      matches: true,
+      userAgent: {
+        family: 'Firefox',
+        version: '40.0.0'
+      }
+    })
 
   expect(matchesUA(ua.firefox('30.0.0'), {browsers: ['Firefox >= 10.0.0']}))
-    .toBe(true)
+    .toEqual({
+      matches: true,
+      userAgent: {
+        family: 'Firefox',
+        version: '30.0.0'
+      }
+    })
 
   expect(matchesUA(ua.chrome.iOS('11.0.0'), {browsers: ['iOS >= 10.3.0']}))
-    .toBe(true)
+    .toEqual({
+      matches: true,
+      userAgent: {
+        family: 'iOS',
+        version: '11.0.0'
+      }
+    })
 
   expect(matchesUA(ua.safari.iOS('11.0.0'), {browsers: ['iOS >= 10.3.0']}))
-    .toBe(true)
+    .toEqual({
+      matches: true,
+      userAgent: {
+        family: 'iOS',
+        version: '11.0.0'
+      }
+    })
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_6_2, {browsers: ['Samsung >= 7']}))
-    .toBe(false)
+    .toEqual({
+      matches: false,
+      userAgent: {
+        family: 'Samsung',
+        version: '6.2.0'
+      }
+    })
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_7_2, {browsers: ['Samsung >= 7']}))
-    .toBe(true)
+    .toEqual({
+      matches: true,
+      userAgent: {
+        family: 'Samsung',
+        version: '7.2.0'
+      }
+    })
 
   const modernList = [
     "Firefox >= 53",
@@ -191,47 +227,113 @@ it('detects if browserslist matches UA', () => {
   ]
 
   expect(matchesUA(ua.safari.iOS(9), {browsers: modernList}))
-    .toBe(false)
+    .toEqual({
+      matches: false,
+      userAgent: {
+        family: 'iOS',
+        version: '9.0.0'
+      }
+    })
 
   expect(matchesUA(ua.chrome.androidPhone(57), {browsers: modernList}))
-    .toBe(false)
+    .toEqual({
+      matches: false,
+      userAgent: {
+        family: 'Chrome',
+        version: '57.0.0'
+      }
+    })
 
   expect(matchesUA(ua.firefox.androidPhone(52), {browsers: modernList}))
-    .toBe(false)
+    .toEqual({
+      matches: false,
+      userAgent: {
+        family: 'Firefox',
+        version: '52.0.0'
+      }
+    })
 
   expect(matchesUA(ua.firefox(56), {browsers: modernList}))
-    .toBe(true)
+    .toEqual({
+      matches: true,
+      userAgent: {
+        family: 'Firefox',
+        version: '56.0.0'
+      }
+    })
 
   expect(matchesUA(ua.edge(14), {browsers: modernList}))
-    .toBe(false)
+    .toEqual({
+      matches: false,
+      userAgent: {
+        family: 'Edge',
+        version: '14.0.0'
+      }
+    })
 
   expect(matchesUA(ua.chrome(64), {browsers: modernList}))
-    .toBe(true)
+    .toEqual({
+      matches: true,
+      userAgent: {
+        family: 'Chrome',
+        version: '64.0.0'
+      }
+    })
 
   expect(matchesUA(ua.chrome.androidWebview('4.3.3'), {browsers: modernList}))
-    .toBe(false)
+    .toEqual({
+      matches: false,
+      userAgent: {
+        family: 'Android',
+        version: '4.3.3'
+      }
+    })
 })
 
 it('can interpret various variations in specifying browser names', () => {
   expect(matchesUA(ua.chrome(49), {browsers: ['and_chr >= 49']}))
-    .toBe(true)
+    .toEqual({
+      matches: true,
+      userAgent: {
+        family: 'Chrome',
+        version: '49.0.0'
+      }
+    })
 
   expect(matchesUA(ua.safari.iOS('10.3.0'), {browsers: ['ios_saf >= 10.1.0']}))
-    .toBe(true)
+    .toEqual({
+      matches: true,
+      userAgent: {
+        family: 'iOS',
+        version: '10.3.0'
+      }
+    })
 
   expect(matchesUA(ua.safari('10.3.0'), {browsers: ['ios_saf >= 10.1.0']}))
-    .toBe(true)
+    .toEqual({
+      matches: true,
+      userAgent: {
+        family: 'iOS',
+        version: '10.3.0'
+      }
+    })
 
   expect(matchesUA(ua.firefox.androidPhone('46.0.0'), {browsers: ['FirefoxAndroid >= 41.1.0']}))
-    .toBe(true)
+    .toEqual({
+      matches: true,
+      userAgent: {
+        family: 'Firefox',
+        version: '46.0.0'
+      }
+    })
 })
 
 it('ignorePatch option works correctly', () => {
   expect(matchesUA(ua.firefox('49.0.1'), {browsers: ['ff >= 44'], ignorePatch: false}))
-    .toBe(false)
+    .toMatchObject({ matches: false })
 
   expect(matchesUA(ua.firefox('49.0.1'), {browsers: ['ff >= 44'], ignorePatch: true}))
-    .toBe(true)
+    .toMatchObject({ matches: true })
 
   expect(
     matchesUA(
@@ -239,15 +341,15 @@ it('ignorePatch option works correctly', () => {
       {browsers: ['ff >= 44'], ignorePatch: true, ignoreMinor: false},
     ),
   )
-    .toBe(false)
+    .toMatchObject({ matches: false })
 })
 
 it('ignoreMinor option works correctly', () => {
   expect(matchesUA(ua.firefox('49.1.0'), {browsers: ['ff >= 44'], ignoreMinor: false}))
-    .toBe(false)
+    .toMatchObject({ matches: false })
 
   expect(matchesUA(ua.firefox('49.1.0'), {browsers: ['ff >= 44'], ignoreMinor: true}))
-    .toBe(true)
+    .toMatchObject({ matches: true })
 
   expect(
     matchesUA(
@@ -255,38 +357,46 @@ it('ignoreMinor option works correctly', () => {
       {browsers: ['ff >= 44'], ignoreMinor: true, ignorePatch: false},
     ),
   )
-    .toBe(true)
+    .toMatchObject({ matches: true })
 })
 
 it('_allowHigherVersions and allowHigherVersions work correctly', () => {
   expect(matchesUA(ua.chrome('99'), {browsers: ['chrome >= 60'], _allowHigherVersions: false}))
-    .toBe(false)
+    .toMatchObject({ matches: false })
 
   expect(matchesUA(ua.chrome('99'), {browsers: ['chrome >= 60'], allowHigherVersions: false}))
-    .toBe(false)
+    .toMatchObject({ matches: false })
 
   expect(matchesUA(ua.chrome('66'), {browsers: ['chrome >= 60'], _allowHigherVersions: true}))
-    .toBe(true)
+    .toMatchObject({ matches: true })
 
   expect(matchesUA(ua.chrome('66'), {browsers: ['chrome >= 60'], allowHigherVersions: true}))
-    .toBe(true)
+    .toMatchObject({ matches: true })
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_6_2, {browsers: ['samsung >= 3'], allowHigherVersions: true}))
-    .toBe(true)
+    .toMatchObject({ matches: true })
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_7_4, {browsers: ['samsung >= 3'], allowHigherVersions: true}))
-    .toBe(true)
+    .toMatchObject({ matches: true })
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_8_2, {browsers: ['samsung >= 3'], allowHigherVersions: true}))
-    .toBe(true)
+    .toMatchObject({ matches: true })
 
   // latest version of samsung browser reported by browserslist is 7.2.0
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_6_2, {browsers: ['samsung >= 3'], allowHigherVersions: false}))
-    .toBe(true)
+    .toMatchObject({ matches: true })
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_7_4, {browsers: ['samsung >= 3'], allowHigherVersions: false}))
-    .toBe(false)
+    .toMatchObject({ matches: false })
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_8_2, {browsers: ['samsung >= 3'], allowHigherVersions: false}))
-    .toBe(false)
+    .toMatchObject({ matches: false })
+})
+
+it('handles an unrecognizable UA', () => {
+  expect(matchesUA('unrecognizable', {browsers: ['Chrome >= 60']}))
+    .toEqual({
+      matches: false,
+      userAgent: null
+    })
 })

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -127,7 +127,7 @@ it('resolves chrome/android properly', () => {
     })
 
   expect(matchesUA(CustomUserAgentString.YANDEX, { browsers: ['Chrome >= 63']}))
-    .toBeTruthy()
+    .toBe(true)
 })
 
 it('resolves firefox properly', () => {
@@ -166,22 +166,22 @@ it('resolves samsung browser properly', () => {
 
 it('detects if browserslist matches UA', () => {
   expect(matchesUA(ua.firefox.androidPhone('40.0.1'), {browsers: ['Firefox >= 40']}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(ua.firefox('30.0.0'), {browsers: ['Firefox >= 10.0.0']}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(ua.chrome.iOS('11.0.0'), {browsers: ['iOS >= 10.3.0']}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(ua.safari.iOS('11.0.0'), {browsers: ['iOS >= 10.3.0']}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_6_2, {browsers: ['Samsung >= 7']}))
-    .toBeFalsy()
+    .toBe(false)
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_7_2, {browsers: ['Samsung >= 7']}))
-    .toBeTruthy()
+    .toBe(true)
 
   const modernList = [
     "Firefox >= 53",
@@ -191,47 +191,47 @@ it('detects if browserslist matches UA', () => {
   ]
 
   expect(matchesUA(ua.safari.iOS(9), {browsers: modernList}))
-    .toBeFalsy()
+    .toBe(false)
 
   expect(matchesUA(ua.chrome.androidPhone(57), {browsers: modernList}))
-    .toBeFalsy()
+    .toBe(false)
 
   expect(matchesUA(ua.firefox.androidPhone(52), {browsers: modernList}))
-    .toBeFalsy()
+    .toBe(false)
 
   expect(matchesUA(ua.firefox(56), {browsers: modernList}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(ua.edge(14), {browsers: modernList}))
-    .toBeFalsy()
+    .toBe(false)
 
   expect(matchesUA(ua.chrome(64), {browsers: modernList}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(ua.chrome.androidWebview('4.3.3'), {browsers: modernList}))
-    .toBeFalsy()
+    .toBe(false)
 })
 
 it('can interpret various variations in specifying browser names', () => {
   expect(matchesUA(ua.chrome(49), {browsers: ['and_chr >= 49']}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(ua.safari.iOS('10.3.0'), {browsers: ['ios_saf >= 10.1.0']}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(ua.safari('10.3.0'), {browsers: ['ios_saf >= 10.1.0']}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(ua.firefox.androidPhone('46.0.0'), {browsers: ['FirefoxAndroid >= 41.1.0']}))
-    .toBeTruthy()
+    .toBe(true)
 })
 
 it('ignorePatch option works correctly', () => {
   expect(matchesUA(ua.firefox('49.0.1'), {browsers: ['ff >= 44'], ignorePatch: false}))
-    .toBeFalsy()
+    .toBe(false)
 
   expect(matchesUA(ua.firefox('49.0.1'), {browsers: ['ff >= 44'], ignorePatch: true}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(
     matchesUA(
@@ -239,15 +239,15 @@ it('ignorePatch option works correctly', () => {
       {browsers: ['ff >= 44'], ignorePatch: true, ignoreMinor: false},
     ),
   )
-    .toBeFalsy()
+    .toBe(false)
 })
 
 it('ignoreMinor option works correctly', () => {
   expect(matchesUA(ua.firefox('49.1.0'), {browsers: ['ff >= 44'], ignoreMinor: false}))
-    .toBeFalsy()
+    .toBe(false)
 
   expect(matchesUA(ua.firefox('49.1.0'), {browsers: ['ff >= 44'], ignoreMinor: true}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(
     matchesUA(
@@ -255,38 +255,38 @@ it('ignoreMinor option works correctly', () => {
       {browsers: ['ff >= 44'], ignoreMinor: true, ignorePatch: false},
     ),
   )
-    .toBeTruthy()
+    .toBe(true)
 })
 
 it('_allowHigherVersions and allowHigherVersions work correctly', () => {
   expect(matchesUA(ua.chrome('99'), {browsers: ['chrome >= 60'], _allowHigherVersions: false}))
-    .toBeFalsy()
+    .toBe(false)
 
   expect(matchesUA(ua.chrome('99'), {browsers: ['chrome >= 60'], allowHigherVersions: false}))
-    .toBeFalsy()
+    .toBe(false)
 
   expect(matchesUA(ua.chrome('66'), {browsers: ['chrome >= 60'], _allowHigherVersions: true}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(ua.chrome('66'), {browsers: ['chrome >= 60'], allowHigherVersions: true}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_6_2, {browsers: ['samsung >= 3'], allowHigherVersions: true}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_7_4, {browsers: ['samsung >= 3'], allowHigherVersions: true}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_8_2, {browsers: ['samsung >= 3'], allowHigherVersions: true}))
-    .toBeTruthy()
+    .toBe(true)
 
   // latest version of samsung browser reported by browserslist is 7.2.0
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_6_2, {browsers: ['samsung >= 3'], allowHigherVersions: false}))
-    .toBeTruthy()
+    .toBe(true)
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_7_4, {browsers: ['samsung >= 3'], allowHigherVersions: false}))
-    .toBeFalsy()
+    .toBe(false)
 
   expect(matchesUA(CustomUserAgentString.SAMSUNG_BROWSER_8_2, {browsers: ['samsung >= 3'], allowHigherVersions: false}))
-    .toBeFalsy()
+    .toBe(false)
 })


### PR DESCRIPTION
`matchesUA()` now returns an object with `matches`, a boolean indicating that the browserslist config matched the UA, and `userAgent`, the resolved user agent family and version. For unrecognizable user agents the `userAgent` is `null`.

This allows consumers to tell apart if the user agent didn't match the browserslist config because:

1. The UA is recognized, but doesn't match the browserslist config.
2. The UA was unrecognizable.

A use case is showing a browser outdated warning to users. At the moment, such a warning displays for Facebook Messenger on Android users, [as the in-app browser has an "Orca" user agent that doesn't correspond to a browserslist family](https://github.com/browserslist/browserslist-useragent/issues/25). In reality, their browser is not out of date, just unrecognized. Ideally, you could display browser out of date warnings _only_ for users with recognized user agents that are *known* to be out of date.