### PR TITLE
Add "allowBots" option to detect and match bots

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,7 +243,7 @@ const matchesUA = (uaString, opts = {}) => {
     ...opts,
   }
 
-  if (options.allowBots) {
+  if (options.allowBots && resolvedUserAgent.family == 'Bot') {
     return true;
   }
 

--- a/index.js
+++ b/index.js
@@ -23,6 +23,38 @@ const browserNameMap = {
   and_uc: 'UCAndroid',
 }
 
+const bots = [
+  'Googlebot',
+  'Googlebot-News',
+  'Googlebot-Image',
+  'Googlebot-Video',
+  'Googlebot-Mobile',
+  'Mediapartners-Google',
+  'AdsBot-Google',
+  'AdsBot-Google-Mobile-Apps',
+  'GooglePlusBot',
+  'Bingbot',
+  'Yahoo! Slurp',
+  'DuckDuckBot',
+  'Baiduspider',
+  'Baiduspider-image',
+  'Baiduspider-video',
+  'Baiduspider-news',
+  'Baiduspider-favo',
+  'Baiduspider-cpro',
+  'Baiduspider-ads',
+  'YandexBot',
+  'Sogou Pic Spider',
+  'Sogou head spider',
+  'Sogou web spider',
+  'Sogou Orion spider',
+  'Sogou-Test-Spider',
+  'Exabot',
+  'facebot',
+  'FacebookBot',
+  'ia_archiver',
+]
+
 function resolveUserAgent(uaString) {
   // Chrome and Opera on iOS uses a UIWebView of the underlying platform to render
   // content, by stripping the CriOS or OPiOS strings the useragent parser will alias the
@@ -36,6 +68,13 @@ function resolveUserAgent(uaString) {
   strippedUA = strippedUA.replace(/YaBrowser\/(\d+\.?)+/g, '')
 
   const parsedUA = useragent.parse(strippedUA)
+
+  if (bots.some(bot => parsedUA.family.toLowerCase() == bot.toLowerCase())) {
+    return {
+      family: 'Bot',
+      version: [parsedUA.major, parsedUA.minor, parsedUA.patch].join('.')
+    }
+  }
 
   // Case A: For Safari, Chrome and others browsers on iOS
   // that report as Safari after stripping tags
@@ -202,6 +241,10 @@ const matchesUA = (uaString, opts = {}) => {
     ignoreMinor: false,
     ignorePatch: true,
     ...opts,
+  }
+
+  if (options.allowBots) {
+    return true;
   }
 
   return parsedBrowsers.some(browser => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -157,6 +157,174 @@ it('resolves samsung browser properly', () => {
     })
 })
 
+it('resolves bots properly', () => {
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '2.1.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Googlebot-News/2.1; +http://www.google.com/bot.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '2.1.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Googlebot-Image/1.0; +http://www.google.com/bot.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '1.0.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Googlebot-Video/1.0; +http://www.google.com/bot.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '1.0.0'
+    })
+  expect(resolveUserAgent("SAMSUNG-SGH-E250/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '2.1.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '2.1.0'
+    })
+  expect(resolveUserAgent("(compatible; Mediapartners-Google/2.1; +http://www.google.com/bot.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '2.1.0'
+    })
+  expect(resolveUserAgent("Mediapartners-Google"))
+    .toEqual({
+      family: 'Bot',
+      version: '0.0.0'
+    })
+  expect(resolveUserAgent("AdsBot-Google (+http://www.google.com/adsbot.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '0.0.0'
+    })
+  expect(resolveUserAgent("AdsBot-Google-Mobile-Apps"))
+    .toEqual({
+      family: 'Bot',
+      version: '0.0.0'
+    })
+  expect(resolveUserAgent("Google (+https://developers.google.com/+/web/snippet/)"))
+    .toEqual({
+      family: 'Bot',
+      version: '0.0.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Bingbot/2.0; +http://www.bing.com/bingbot.htm)"))
+    .toEqual({
+      family: 'Bot',
+      version: '0.0.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)"))
+    .toEqual({
+      family: 'Bot',
+      version: '0.0.0'
+    })
+  expect(resolveUserAgent("DuckDuckBot/1.0; (+http://duckduckgo.com/duckduckbot.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '1.0.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '2.0.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Baiduspider-image/2.0; +http://www.baidu.com/search/spider.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '2.0.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Baiduspider-video/2.0; +http://www.baidu.com/search/spider.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '2.0.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Baiduspider-news/2.0; +http://www.baidu.com/search/spider.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '2.0.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Baiduspider-favo/2.0; +http://www.baidu.com/search/spider.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '2.0.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Baiduspider-cpro/2.0; +http://www.baidu.com/search/spider.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '2.0.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Baiduspider-ads/2.0; +http://www.baidu.com/search/spider.html)"))
+    .toEqual({
+      family: 'Bot',
+      version: '2.0.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)"))
+    .toEqual({
+      family: 'Bot',
+      version: '3.0.0'
+    })
+  expect(resolveUserAgent("Sogou Pic Spider/3.0( http://www.sogou.com/docs/help/webmasters.htm#07)"))
+    .toEqual({
+      family: 'Bot',
+      version: '3.0.0'
+    })
+  expect(resolveUserAgent("Sogou head spider/3.0( http://www.sogou.com/docs/help/webmasters.htm#07)"))
+    .toEqual({
+      family: 'Bot',
+      version: '3.0.0'
+    })
+  expect(resolveUserAgent("Sogou web spider/4.0(+http://www.sogou.com/docs/help/webmasters.htm#07)"))
+    .toEqual({
+      family: 'Bot',
+      version: '4.0.0'
+    })
+  expect(resolveUserAgent("Sogou Orion spider/3.0( http://www.sogou.com/docs/help/webmasters.htm#07)"))
+    .toEqual({
+      family: 'Bot',
+      version: '3.0.0'
+    })
+  expect(resolveUserAgent("Sogou-Test-Spider/4.0 (compatible; MSIE 5.5; Windows 98)"))
+    .toEqual({
+      family: 'Bot',
+      version: '4.0.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Konqueror/3.5; Linux) KHTML/3.5.5 (like Gecko) (Exabot-Thumbnails)"))
+    .toEqual({
+      family: 'Bot',
+      version: '0.0.0'
+    })
+  expect(resolveUserAgent("Mozilla/5.0 (compatible; Exabot/3.0; +http://www.exabot.com/go/robot)"))
+    .toEqual({
+      family: 'Bot',
+      version: '3.0.0'
+    })
+  expect(resolveUserAgent("facebot"))
+    .toEqual({
+      family: 'Bot',
+      version: '0.0.0'
+    })
+  expect(resolveUserAgent("facebookexternalhit/1.0 (+http://www.facebook.com/externalhit_uatext.php)"))
+    .toEqual({
+      family: 'Bot',
+      version: '1.0.0'
+    })
+  expect(resolveUserAgent("facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"))
+    .toEqual({
+      family: 'Bot',
+      version: '1.1.0'
+    })
+  expect(resolveUserAgent("ia_archiver (+http://www.alexa.com/site/help/webmasters; crawler@alexa.com)"))
+    .toEqual({
+      family: 'Bot',
+      version: '0.0.0'
+    })
+})
+
 it('detects if browserslist matches UA', () => {
   expect(matchesUA(ua.firefox.androidPhone('40.0.1'), { browsers: ['Firefox >= 40'] }))
     .toBeTruthy()
@@ -262,6 +430,15 @@ it('allowHigherVersions works correctly', () => {
 
   expect(matchesUA(ua.chrome('66'), { browsers: ['chrome >= 60'], allowHigherVersions: true }))
     .toBeTruthy()
+})
+
+it('allowBots works correctly', () => {
+  expect(matchesUA("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"))
+    .toBeFalsy();
+  expect(matchesUA("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)", { allowBots: false }))
+    .toBeFalsy();
+  expect(matchesUA("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)", { allowBots: true }))
+    .toBeTruthy();
 })
 
 it('parses semvers liberally', () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -435,9 +435,19 @@ it('allowHigherVersions works correctly', () => {
 it('allowBots works correctly', () => {
   expect(matchesUA("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"))
     .toBeFalsy();
+  expect(matchesUA(ua.chrome('59'), { browsers: ['chrome >= 60'] }))
+    .toBeFalsy();
+  expect(matchesUA(ua.chrome('66'), { browsers: ['chrome >= 60'] }))
+    .toBeTruthy();
   expect(matchesUA("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)", { allowBots: false }))
     .toBeFalsy();
+  expect(matchesUA(ua.chrome('59'), { browsers: ['chrome >= 60'], allowBots: false }))
+    .toBeFalsy();
+  expect(matchesUA(ua.chrome('66'), { browsers: ['chrome >= 60'], allowBots: false }))
+    .toBeTruthy();
   expect(matchesUA("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)", { allowBots: true }))
+    .toBeTruthy();
+  expect(matchesUA(ua.chrome('66'), { browsers: ['chrome >= 60'], allowBots: true }))
     .toBeTruthy();
 })
 


### PR DESCRIPTION
Hello there,

I have found that the lib doesn't resolve bots correctly what may cause problems with crawling the website which uses matchesUA to detect if the user's browser is supported.

Here's a very basic implementation of such crawlers resolution with option `allowBots` to allow such crawlers to use the website or not.

If you have any suggestions just let me know.