### PR TITLE
Allow to specify path in browserslist options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ matchesUA('Mozilla/5.0 (Windows NT 10.0; rv:54.0) Gecko/20100101 Firefox/54.0', 
 |--------|---------------|------------ |
 | browsers | — | Manually provide a browserslist query (or an array of queries). Specifying this overrides the browserslist configuration specified in your project. |
 | env | — | When multiple browserslist [environments](https://github.com/ai/browserslist#environments) are specified, pick the config belonging to this environment.|
-| path | — | Specify .browserslistrc path if differs from `process.cwd()`|
+| path | `process.cwd()` | Specify a folder to search for the browserslist config (if it differs from the current working directory) |
 | ignorePatch | `true` | Ignore differences in patch browser numbers |
 | ignoreMinor | `false` | Ignore differences in minor browser versions |
 | allowHigherVersions | `false` | For all the browsers in the browserslist query, return a match if the user agent version is equal to or higher than the one specified in browserslist. See [why](#when-querying-for-modern-browsers) this might be useful.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ matchesUA('Mozilla/5.0 (Windows NT 10.0; rv:54.0) Gecko/20100101 Firefox/54.0', 
 |--------|---------------|------------ |
 | browsers | — | Manually provide a browserslist query (or an array of queries). Specifying this overrides the browserslist configuration specified in your project. |
 | env | — | When multiple browserslist [environments](https://github.com/ai/browserslist#environments) are specified, pick the config belonging to this environment.|
+| path | — | Specify .browserslistrc path if differs from `process.cwd()`|
 | ignorePatch | `true` | Ignore differences in patch browser numbers |
 | ignoreMinor | `false` | Ignore differences in minor browser versions |
 | allowHigherVersions | `false` | For all the browsers in the browserslist query, return a match if the user agent version is equal to or higher than the one specified in browserslist. See [why](#when-querying-for-modern-browsers) this might be useful.

--- a/index.js
+++ b/index.js
@@ -224,7 +224,7 @@ const matchesUA = (uaString, opts = {}) => {
   }
   const browsers = browserslist(normalizedQuery, {
     env: opts.env,
-    path: process.cwd()
+    path: opts.path || process.cwd()
   })
   const parsedBrowsers = parseBrowsersList(browsers)
 


### PR DESCRIPTION
In our case nodeJS starts in docker with supervisor. And process.cwd() is out of scope where .browserslistrc is. We need to specify it's location.