### PR TITLE
fix: match safari technology preview without using semver. Fixes #38

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,6 +211,9 @@ const compareBrowserSemvers = (versionA, versionB, options) => {
   }
 
   if (options.allowHigherVersions) {
+    if (semverifiedB === "TP.0.0") {
+      return semverifiedA === semverifiedB;
+    }
     return semver.gte(semverifiedA, semverifiedB)
   } else {
     return semver.satisfies(semverifiedA, referenceVersion)


### PR DESCRIPTION
This fixes #38 by manually testing for Safari technology preview, rather than using semver. 