### PR TITLE
Use semver.coerce instead of custom logic to more reliably parse versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,22 +117,7 @@ function resolveUserAgent(uaString) {
 
 // Convert version to a semver value.
 // 2.5 -> 2.5.0; 1 -> 1.0.0;
-const semverify = (version) => {
-  if (
-    typeof version === 'string' &&
-    semver.valid(version, { loose: true })
-  ) {
-    return semver.parse(version, { loose: true }).version
-  }
-
-  const split = version.toString().split('.')
-
-  while (split.length < 3) {
-    split.push('0')
-  }
-
-  return split.join('.')
-}
+const semverify = (version) => semver.coerce(version, { loose: true }).version;
 
 function flatten(arr) {
   return arr.reduce(function (flat, toFlatten) {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -296,6 +296,9 @@ it('parses semvers liberally', () => {
   expect(
     matchesUA('Opera/9.80 (Windows NT 6.1; U; es-ES) Presto/2.9.181 Version/12.0.0001', { browsers: ['opera >= 12'] }))
     .toBeTruthy()
+
+  expect(matchesUA('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.1b2pre) Gecko/20081015 Fennec/55.0a1', { browsers: ['firefox > 50'], allowHigherVersions: false }))
+    .toBeTruthy()
 })
 
 it('can deal with version ranges (if returned by browserslist)', () => {


### PR DESCRIPTION
**Problem**
Closes #52. Currently, when we cannot `.parse()` a given semver value, we fall back to custom logic which is not well equipped to handle variations like the alpha tag. This means later on, when we go to compare versions, semver throws an error.

**Solution**
Instead of relying on our own code to `semverify`. Use semver.coerce which should always be better equipped to deal with variations. Under the hood, this ultimately calls `.parse`, so it ends up more or less being a good drop in for the whole function.

Added a test with an example offending UA that will fail previously and pass now.