### PR TITLE
fix(matchesUa): fail gracefully on invalid UA

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,6 +224,11 @@ const compareBrowserSemvers = (versionA, versionB, options) => {
 }
 
 const matchesUA = (uaString, opts = {}) => {
+  // bail out early if the user agent is invalid
+  if (!uaString) {
+    return false;
+  }
+
   let normalizedQuery
   if (opts.browsers) {
     normalizedQuery = opts.browsers.map(normalizeQuery)

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -325,3 +325,16 @@ it('can deal with non-numerical version numbers returned by browserslist for saf
     }))
     .toBeTruthy()
 })
+
+it('gracefully fails on invalid inputs', () => {
+  expect(
+    matchesUA(undefined))
+    .toBeFalsy()
+
+  expect(
+    matchesUA(null))
+    .toBeFalsy()
+})
+
+
+


### PR DESCRIPTION
Right now, the matchesUA function will throw the following exception if an invalid userAgent is provided:

```
TypeError: Cannot read property 'replace' of undefined
```

This function should fail gracefully, as there are times when a userAgent may be missing (tests, etc). 

This PR provides failing tests as an example of the issue, and a fix.

Fixes https://github.com/browserslist/browserslist-useragent/issues/66

Thanks!

